### PR TITLE
feat: upgrade provider to Vercel AI SDK v5

### DIFF
--- a/.changeset/spice-provider-ai-sdk-v5.md
+++ b/.changeset/spice-provider-ai-sdk-v5.md
@@ -1,0 +1,13 @@
+---
+"@spiceai/spice-ai-provider": minor
+---
+
+Upgrade to Vercel AI SDK v5.
+
+The provider now implements the AI SDK v5 provider interface (`LanguageModelV2` / `ProviderV2`) so it works with `ai@^5`. It is rebuilt on top of `@ai-sdk/openai-compatible` instead of reaching into `@ai-sdk/openai/internal`, which is more stable across AI SDK releases.
+
+- Dependencies: `@ai-sdk/provider` `^1` → `^2`, `@ai-sdk/provider-utils` `^2` → `^3`; replace `@ai-sdk/openai` with `@ai-sdk/openai-compatible@^1`.
+- `peerDependencies.zod` widened to `^3.25.76 || ^4.1.8` to match the v5 SDK.
+- Public API (`createSpice`, `createSpiceCloud`, `spice`, `SpiceProvider`, `SpiceProviderSettings`) and the `chat` / `completion` / `languageModel` / `textEmbeddingModel` methods are unchanged. Spice Cloud authentication continues to use the `X-API-KEY` header.
+
+This is a breaking change for consumers: the provider now requires AI SDK v5 (`ai@^5`) and is no longer compatible with `ai@^4`.

--- a/examples/sample-app/app/actions.tsx
+++ b/examples/sample-app/app/actions.tsx
@@ -1,12 +1,12 @@
 "use server";
 
-import { createStreamableValue } from "ai/rsc";
-import { CoreMessage, streamText } from "ai";
+import { createStreamableValue } from "@ai-sdk/rsc";
+import { type ModelMessage, streamText } from "ai";
 import { createSpice } from "@spiceai/spice-ai-provider";
 
 const spice = createSpice();
 
-export async function continueConversation(messages: CoreMessage[]) {
+export async function continueConversation(messages: ModelMessage[]) {
   const result = await streamText({
     model: spice.chat("o3-mini"),
     messages,

--- a/examples/sample-app/app/page.tsx
+++ b/examples/sample-app/app/page.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-import { type CoreMessage } from "ai";
+import { type ModelMessage } from "ai";
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGFM from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import remarkBreaks from "remark-breaks";
 import { continueConversation } from "./actions";
-import { readStreamableValue } from "ai/rsc";
+import { readStreamableValue } from "@ai-sdk/rsc";
 
 export const maxDuration = 30;
 
 export default function Chat() {
-  const [messages, setMessages] = useState<CoreMessage[]>([]);
+  const [messages, setMessages] = useState<ModelMessage[]>([]);
   const [input, setInput] = useState("");
   return (
     <div className="flex flex-col gap-8 w-full max-w-4xl py-24 px-8 mx-auto stretch">
@@ -32,7 +32,7 @@ export default function Chat() {
       <form
         onSubmit={async (e) => {
           e.preventDefault();
-          const newMessages: CoreMessage[] = [
+          const newMessages: ModelMessage[] = [
             ...messages,
             { content: input, role: "user" },
           ];

--- a/examples/sample-app/package.json
+++ b/examples/sample-app/package.json
@@ -9,9 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@ai-sdk/rsc": "^1.0.197",
     "@radix-ui/react-icons": "^1.3.0",
     "@spiceai/spice-ai-provider": "*",
-    "ai": "^4.1.13",
+    "ai": "^5.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.439.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,9 +97,10 @@
     "examples/sample-app": {
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/rsc": "^1.0.197",
         "@radix-ui/react-icons": "^1.3.0",
         "@spiceai/spice-ai-provider": "*",
-        "ai": "^4.1.13",
+        "ai": "^5.0.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.439.0",
@@ -127,84 +128,6 @@
         "postcss": "^8.4.45",
         "tailwindcss": "^3.4.10",
         "typescript": "^5"
-      }
-    },
-    "examples/sample-app/node_modules/@ai-sdk/ui-utils": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.1.7.tgz",
-      "integrity": "sha512-S9Q9rCvMPUe/RP5gc1kSn6yLe/4CFrvLP7H47Dcq5c0z6NEYDySL+ycecB6V2eRyxqxsVneL2zOvX6aubDhz1w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.0.6",
-        "@ai-sdk/provider-utils": "2.1.5",
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "examples/sample-app/node_modules/ai": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-4.1.13.tgz",
-      "integrity": "sha512-tEr3gt2X2NkCBDSxyeFRnWQ17AlfYYnH/2eImfakuq0AJBYRwk3VYK2twKd0gGFXVd6xBdlae5/PybpSiAyCbA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.0.6",
-        "@ai-sdk/provider-utils": "2.1.5",
-        "@ai-sdk/react": "1.1.7",
-        "@ai-sdk/ui-utils": "1.1.7",
-        "@opentelemetry/api": "1.9.0",
-        "jsondiffpatch": "0.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "examples/sample-app/node_modules/ai/node_modules/@ai-sdk/react": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.1.7.tgz",
-      "integrity": "sha512-QvTXmv+b05Q4cdruxt6UrM8qCcVOVFEAoJxemC/VV0Hyp6f+Udrm4KGDRwqtijGpl3P3zN1+7JwSUI9wOBz0Qw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "2.1.5",
-        "@ai-sdk/ui-utils": "1.1.7",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "examples/sample-app/node_modules/postcss": {
@@ -235,61 +158,43 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/@ai-sdk/openai": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.1.9.tgz",
-      "integrity": "sha512-t/CpC4TLipdbgBJTMX/otzzqzCMBSPQwUOkYPGbT/jyuC86F+YO9o+LS0Ty2pGUE1kyT+B3WmJ318B16ZCg4hw==",
+    "node_modules/@ai-sdk/gateway": {
+      "version": "2.0.96",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.96.tgz",
+      "integrity": "sha512-2Ue0jetdlGQNv8zzYkZHgQQUfoeBp+Vu97L5UAF+HHJ/EggvY2lvO19Mq0G4YEPvc2Xt77QdDz5gGySxDSMpMQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.7",
-        "@ai-sdk/provider-utils": "2.1.6"
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25",
+        "@vercel/oidc": "3.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.7.tgz",
-      "integrity": "sha512-q1PJEZ0qD9rVR+8JFEd01/QM++csMT5UVwYXSN2u54BrVw/D8TZLTeg2FEfKK00DgAx0UtWd8XOhhwITP9BT5g==",
+    "node_modules/@ai-sdk/openai-compatible": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-1.0.39.tgz",
+      "integrity": "sha512-001hdQPPXxYBWrz5d+eAmBVYmwzsB+guIey1DFXi1ZEE5H3j7fRrhPpX55MdM9Fle2DS7WZ8b3qkumCIWE92YQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.6.tgz",
-      "integrity": "sha512-Pfyaj0QZS22qyVn5Iz7IXcJ8nKIKlu2MeSAdKJzTwkAks7zdLaKVB+396Rqcp1bfQnxl7vaduQVMQiXUrgK8Gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.0.7",
-        "eventsource-parser": "^3.0.0",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.6.tgz",
-      "integrity": "sha512-hwj/gFNxpDgEfTaYzCYoslmw01IY9kWLKl/wf8xuPvHtQIzlfXWmmUwc8PnCwxyt8cKzIuV0dfUghCf68HQ0SA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -299,26 +204,59 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.5.tgz",
-      "integrity": "sha512-PcNR7E4ovZGV/J47gUqaFlvzorgca6uUfN5WzfXJSFWeOeLunN+oxRVwgUOwj0zbmO0yGQTHQD+FHVw8s3Rz8w==",
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.25.tgz",
+      "integrity": "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.6",
-        "eventsource-parser": "^3.0.0",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
+        "@ai-sdk/provider": "2.0.3",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/rsc": {
+      "version": "1.0.197",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/rsc/-/rsc-1.0.197.tgz",
+      "integrity": "sha512-w24uktMAMPLw0hrnpqPOpe8Yz3j0h3uF5eY1/6AfOXdzScCVcYnnBDUqujph9zsa1HMgxqieeyJPSA8KJwaeMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25",
+        "ai": "5.0.195",
+        "jsondiffpatch": "0.7.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1",
+        "zod": "^3.25.76 || ^4.1.8"
       },
       "peerDependenciesMeta": {
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@ai-sdk/rsc/node_modules/jsondiffpatch": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.7.3.tgz",
+      "integrity": "sha512-zd4dqFiXSYyant2WgSXAZ9+yYqilNVvragVNkNRn2IFZKgjyULNrKRznqN4Zon0MkLueCg+3QaPVCnDAVP20OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dmsnell/diff-match-patch": "^1.1.0"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -527,19 +465,21 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -582,12 +522,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
-      "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.6"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -640,14 +581,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
-      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -950,29 +891,11 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
+    "node_modules/@dmsnell/diff-match-patch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@dmsnell/diff-match-patch/-/diff-match-patch-1.1.0.tgz",
+      "integrity": "sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.23.1",
@@ -1634,9 +1557,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1858,7 +1782,6 @@
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2115,6 +2038,12 @@
       "resolved": "packages/spice-ai-provider",
       "link": true
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -2157,34 +2086,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2192,11 +2093,6 @@
       "dependencies": {
         "@types/ms": "*"
       }
-    },
-    "node_modules/@types/diff-match-patch": {
-      "version": "1.0.36",
-      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
-      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -2482,6 +2378,15 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vercel/style-guide": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@vercel/style-guide/-/style-guide-5.2.0.tgz",
@@ -2758,17 +2663,22 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "optional": true,
-      "peer": true,
+    "node_modules/ai": {
+      "version": "5.0.195",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.195.tgz",
+      "integrity": "sha512-tWoeMhKZ2Gtx4SrcZM1PnhdlledqdrWgtdsJbPS+LEC2O3C0ZaPGjgxHcew+hhc0E5Vu5fpaGB0sLx3qU/ajgA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "acorn": "^8.11.0"
+        "@ai-sdk/gateway": "2.0.96",
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25",
+        "@opentelemetry/api": "1.9.0"
       },
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -2831,13 +2741,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3478,13 +3381,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3510,9 +3406,10 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3716,21 +3613,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/diff-match-patch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
-      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -5233,9 +5115,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.0.tgz",
-      "integrity": "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -6662,33 +6544,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsondiffpatch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
-      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
-      "dependencies": {
-        "@types/diff-match-patch": "^1.0.36",
-        "chalk": "^5.3.0",
-        "diff-match-patch": "^1.0.5"
-      },
-      "bin": {
-        "jsondiffpatch": "bin/jsondiffpatch.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
-    "node_modules/jsondiffpatch/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -6864,13 +6719,6 @@
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/markdown-table": {
       "version": "3.0.3",
@@ -7793,9 +7641,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -9316,11 +9164,6 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
-    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -9898,19 +9741,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/swr": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.0.tgz",
-      "integrity": "sha512-NyZ76wA4yElZWBHzSgEJc28a0u6QZvhb6w0azeL2k7+Q1gAzVK+IqQYXhVOC/mzi+HZIozrZvBVeSeOZNR2bqA==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/synckit": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
@@ -10083,18 +9913,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/throttleit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -10104,15 +9922,6 @@
       },
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {
@@ -10178,50 +9987,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
-    },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -10687,26 +10452,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/use-sync-external-store": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
-      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -10955,16 +10704,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -10978,21 +10717,12 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
-      "integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     },
     "node_modules/zwitch": {
@@ -11023,53 +10753,18 @@
       "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/openai": "^1.1.9",
-        "@ai-sdk/provider": "^1.0.7",
-        "@ai-sdk/provider-utils": "^2.1.6"
+        "@ai-sdk/openai-compatible": "^1.0.39",
+        "@ai-sdk/provider": "^2.0.3",
+        "@ai-sdk/provider-utils": "^3.0.25"
       },
       "devDependencies": {
         "@repo/typescript-config": "*",
         "tsup": "^8.2.4",
         "typescript": "latest",
-        "zod": "^3.23.8"
+        "zod": "^3.25.76"
       },
       "peerDependencies": {
-        "zod": "^3.0.0"
-      }
-    },
-    "packages/spice-ai-provider/node_modules/@ai-sdk/provider": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.7.tgz",
-      "integrity": "sha512-q1PJEZ0qD9rVR+8JFEd01/QM++csMT5UVwYXSN2u54BrVw/D8TZLTeg2FEfKK00DgAx0UtWd8XOhhwITP9BT5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/spice-ai-provider/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.6.tgz",
-      "integrity": "sha512-Pfyaj0QZS22qyVn5Iz7IXcJ8nKIKlu2MeSAdKJzTwkAks7zdLaKVB+396Rqcp1bfQnxl7vaduQVMQiXUrgK8Gw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.0.7",
-        "eventsource-parser": "^3.0.0",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "packages/typescript-config": {
@@ -11114,6 +10809,141 @@
       "name": "@repo/typescript-config",
       "version": "0.0.0",
       "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.10.tgz",
+      "integrity": "sha512-V3z10NV+cvMAfxQUMhKgfQnPbjw+Ew3cnr64b0lr8MDiBJs3eLnM6RpGC46nhfMZsiXgQngCJKWGTC/yDcgrDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.10.tgz",
+      "integrity": "sha512-Y0TC+FXbFUQ2MQgimJ/7Ina2mXIKhE7F+GUe1SgnzRmwFY3hX2z8nyVCxE82I2RicspdkZnSWMn4oTjIKz4uzA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.10.tgz",
+      "integrity": "sha512-ZfQ7yOy5zyskSj9rFpa0Yd7gkrBnJTkYVSya95hX3zeBG9E55Z6OTNPn1j2BTFWvOVVj65C3T+qsjOyVI9DQpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.10.tgz",
+      "integrity": "sha512-n2i5o3y2jpBfXFRxDREr342BGIQCJbdAUi/K4q6Env3aSx8erM9VuKXHw5KNROK9ejFSPf0LhoSkU/ZiNdacpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.10.tgz",
+      "integrity": "sha512-GXvajAWh2woTT0GKEDlkVhFNxhJS/XdDmrVHrPOA83pLzlGPQnixqxD8u3bBB9oATBKB//5e4vpACnx5Vaxdqg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.10.tgz",
+      "integrity": "sha512-opFFN5B0SnO+HTz4Wq4HaylXGFV+iHrVxd3YvREUX9K+xfc4ePbRrxqOuPOFjtSuiVouwe6uLeDtabjEIbkmDA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.10.tgz",
+      "integrity": "sha512-9NUzZuR8WiXTvv+EiU/MXdcQ1XUvFixbLIMNQiVHuzs7ZIFrJDLJDaOF1KaqttoTujpcxljM/RNAOmw1GhPPQQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.10.tgz",
+      "integrity": "sha512-fr3aEbSd1GeW3YUMBkWAu4hcdjZ6g4NBl1uku4gAn661tcxd1bHs1THWYzdsbTRLcCKLjrDZlNp6j2HTfrw+Bg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.10.tgz",
+      "integrity": "sha512-UjeVoRGKNL2zfbcQ6fscmgjBAS/inHBh63mjIlfPg/NG8Yn2ztqylXt5qilYb6hoHIwaU2ogHknHWWmahJjgZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/packages/spice-ai-provider/package.json
+++ b/packages/spice-ai-provider/package.json
@@ -26,15 +26,15 @@
     "@repo/typescript-config": "*",
     "tsup": "^8.2.4",
     "typescript": "latest",
-    "zod": "^3.23.8"
+    "zod": "^3.25.76"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^1.1.9",
-    "@ai-sdk/provider": "^1.0.7",
-    "@ai-sdk/provider-utils": "^2.1.6"
+    "@ai-sdk/openai-compatible": "^1.0.39",
+    "@ai-sdk/provider": "^2.0.3",
+    "@ai-sdk/provider-utils": "^3.0.25"
   },
   "peerDependencies": {
-    "zod": "^3.0.0"
+    "zod": "^3.25.76 || ^4.1.8"
   },
   "homepage": "https://spiceai.org",
   "repository": {

--- a/packages/spice-ai-provider/src/spice-provider.ts
+++ b/packages/spice-ai-provider/src/spice-provider.ts
@@ -13,6 +13,21 @@ import type {
 const SPICE_LOCAL_BASE_URL = "http://localhost:8090/v1";
 const SPICE_CLOUD_BASE_URL = "https://data.spiceai.io/v1";
 
+// Returns true only when the base URL's host is `spiceai.io` or a subdomain of
+// it. Parsing the URL and matching on the hostname (rather than a substring
+// `includes(".spiceai.io")`) prevents hosts like `evil.spiceai.io.attacker.com`
+// or `attacker.com/?x=.spiceai.io` from being treated as Spice Cloud and being
+// sent the API key.
+function isSpiceCloudUrl(url: string): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+  return hostname === "spiceai.io" || hostname.endsWith(".spiceai.io");
+}
+
 export interface SpiceProvider extends Omit<ProviderV2, "imageModel"> {
   (modelId: string): LanguageModelV2;
 
@@ -39,7 +54,7 @@ export function createSpice(
     withoutTrailingSlash(options.baseURL ?? SPICE_LOCAL_BASE_URL) ??
     SPICE_LOCAL_BASE_URL;
 
-  const isSpiceCloud = baseURL.includes(".spiceai.io");
+  const isSpiceCloud = isSpiceCloudUrl(baseURL);
 
   // The API key is required only for the Spice Cloud endpoint, and Spice expects
   // it in the `X-API-KEY` header rather than the OpenAI-style `Authorization:

--- a/packages/spice-ai-provider/src/spice-provider.ts
+++ b/packages/spice-ai-provider/src/spice-provider.ts
@@ -1,42 +1,28 @@
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import {
-  EmbeddingModelV1,
-  LanguageModelV1,
-  ProviderV1,
-} from "@ai-sdk/provider";
-import {
-  OpenAIChatLanguageModel,
-  OpenAIChatSettings,
-  OpenAICompletionLanguageModel,
-  OpenAICompletionSettings,
-  OpenAIEmbeddingModel,
-  OpenAIEmbeddingSettings,
-} from "@ai-sdk/openai/internal";
-import {
-  withoutTrailingSlash,
   loadApiKey,
+  withoutTrailingSlash,
   type FetchFunction,
 } from "@ai-sdk/provider-utils";
+import type {
+  EmbeddingModelV2,
+  LanguageModelV2,
+  ProviderV2,
+} from "@ai-sdk/provider";
 
 const SPICE_LOCAL_BASE_URL = "http://localhost:8090/v1";
 const SPICE_CLOUD_BASE_URL = "https://data.spiceai.io/v1";
 
-export interface SpiceProvider extends ProviderV1 {
-  languageModel(
-    modelId: string,
-    settings?: OpenAIChatSettings,
-  ): LanguageModelV1;
+export interface SpiceProvider extends Omit<ProviderV2, "imageModel"> {
+  (modelId: string): LanguageModelV2;
 
-  chat(modelId: string, settings?: OpenAIChatSettings): LanguageModelV1;
+  languageModel(modelId: string): LanguageModelV2;
 
-  completion(
-    modelId: string,
-    settings?: OpenAICompletionSettings,
-  ): LanguageModelV1;
+  chat(modelId: string): LanguageModelV2;
 
-  textEmbeddingModel(
-    modelId: string,
-    settings?: OpenAIEmbeddingSettings,
-  ): EmbeddingModelV1<string>;
+  completion(modelId: string): LanguageModelV2;
+
+  textEmbeddingModel(modelId: string): EmbeddingModelV2<string>;
 }
 
 export interface SpiceProviderSettings {
@@ -49,82 +35,61 @@ export interface SpiceProviderSettings {
 export function createSpice(
   options: SpiceProviderSettings = {},
 ): SpiceProvider {
-  const baseURL = withoutTrailingSlash(options.baseURL ?? SPICE_LOCAL_BASE_URL);
+  const baseURL =
+    withoutTrailingSlash(options.baseURL ?? SPICE_LOCAL_BASE_URL) ??
+    SPICE_LOCAL_BASE_URL;
 
-  const isSpiceCloud = baseURL?.includes(".spiceai.io");
+  const isSpiceCloud = baseURL.includes(".spiceai.io");
 
-  // api_key required only for spice cloud provider
-  const getHeaders = isSpiceCloud
-    ? () => ({
-        "X-API-KEY": loadApiKey({
-          apiKey: options.apiKey,
-          environmentVariableName: "SPICE_API_KEY",
-          description: "Spice AI",
-        }),
-        ...options.headers,
-      })
-    : () => ({ ...options.headers });
+  // The API key is required only for the Spice Cloud endpoint, and Spice expects
+  // it in the `X-API-KEY` header rather than the OpenAI-style `Authorization:
+  // Bearer` header — so it is supplied via `headers`, not the `apiKey` option.
+  const headers: Record<string, string> = {
+    ...(isSpiceCloud
+      ? {
+          "X-API-KEY": loadApiKey({
+            apiKey: options.apiKey,
+            environmentVariableName: "SPICE_API_KEY",
+            description: "Spice AI",
+          }),
+        }
+      : {}),
+    ...options.headers,
+  };
 
-  const url = ({ path }: { path: string }) => `${baseURL}${path}`;
+  const openaiCompatible = createOpenAICompatible({
+    name: "spiceai",
+    baseURL,
+    headers,
+    fetch: options.fetch,
+  });
 
-  const createChatModel = (
-    modelId: string,
-    settings: OpenAIChatSettings = {},
-  ) =>
-    new OpenAIChatLanguageModel(modelId, settings, {
-      provider: "spiceai.chat",
-      url,
-      headers: getHeaders,
-      compatibility: "compatible",
-      fetch: options.fetch,
-    });
+  const createChatModel = (modelId: string): LanguageModelV2 =>
+    openaiCompatible.chatModel(modelId);
 
-  const createCompletionModel = (
-    modelId: string,
-    settings: OpenAICompletionSettings = {},
-  ) =>
-    new OpenAICompletionLanguageModel(modelId, settings, {
-      provider: "spiceai.completion",
-      url,
-      compatibility: "compatible",
-      headers: getHeaders,
-      fetch: options.fetch,
-    });
-
-  const createEmbeddingModel = (
-    modelId: string,
-    settings: OpenAIEmbeddingSettings = {},
-  ) =>
-    new OpenAIEmbeddingModel(modelId, settings, {
-      provider: "spiceai.embeddings",
-      headers: getHeaders,
-      url,
-      fetch: options.fetch,
-    });
-
-  const provider = function (
-    modelId: string,
-    settings?: OpenAIChatSettings | OpenAICompletionSettings,
-  ) {
+  function provider(modelId: string): LanguageModelV2 {
     if (new.target) {
       throw new Error(
         "The Spice model function cannot be called with the new keyword.",
       );
     }
 
-    return createChatModel(modelId, settings as OpenAIChatSettings);
-  };
+    return createChatModel(modelId);
+  }
 
-  provider.languageModel = createChatModel;
-  provider.chat = createChatModel;
-  provider.completion = createCompletionModel;
-  provider.textEmbedding = createEmbeddingModel;
-  provider.textEmbeddingModel = createEmbeddingModel;
-
-  return provider as SpiceProvider;
+  return Object.assign(provider, {
+    languageModel: createChatModel,
+    chat: createChatModel,
+    completion: (modelId: string): LanguageModelV2 =>
+      openaiCompatible.completionModel(modelId),
+    textEmbeddingModel: (modelId: string): EmbeddingModelV2<string> =>
+      openaiCompatible.textEmbeddingModel(modelId),
+  }) as SpiceProvider;
 }
 
-export function createSpiceCloud(options: SpiceProviderSettings = {}) {
+export function createSpiceCloud(
+  options: SpiceProviderSettings = {},
+): SpiceProvider {
   return createSpice({
     baseURL: options.baseURL ?? SPICE_CLOUD_BASE_URL,
     ...options,


### PR DESCRIPTION
## Upgrade `@spiceai/spice-ai-provider` to Vercel AI SDK v5

The provider currently targets AI SDK **v4** (`@ai-sdk/provider@^1`, `LanguageModelV1`) and reaches into `@ai-sdk/openai/internal`. That makes it incompatible with `ai@^5`, which uses the `LanguageModelV2` provider spec (`@ai-sdk/provider@^2`). This PR migrates the provider to v5 so downstream apps can move to `ai@^5`.

### What changed

- **Provider implementation** rebuilt on top of [`@ai-sdk/openai-compatible`](https://www.npmjs.com/package/@ai-sdk/openai-compatible) instead of the internal `@ai-sdk/openai/internal` classes. This is the officially supported way to wrap an OpenAI-compatible endpoint and is far more stable across AI SDK releases (no `/internal` imports).
- **Implements the v5 interface:** `LanguageModelV2` / `ProviderV2` (`Omit<ProviderV2, "imageModel">`, mirroring how `@ai-sdk/openai-compatible` declares itself).
- **Dependencies:** `@ai-sdk/provider` `^1.0.7` → `^2.0.3`, `@ai-sdk/provider-utils` `^2.1.6` → `^3.0.25`; **drop** `@ai-sdk/openai`, **add** `@ai-sdk/openai-compatible@^1.0.39`.
- **`peerDependencies.zod`** widened to `^3.25.76 || ^4.1.8` to match the v5 SDK.
- **Sample app** updated to `ai@^5` — `ai/rsc` → `@ai-sdk/rsc`, `CoreMessage` → `ModelMessage`.

### Public API — unchanged

`createSpice`, `createSpiceCloud`, `spice`, `SpiceProvider`, `SpiceProviderSettings` keep the same shapes, and the provider still exposes `chat` / `completion` / `languageModel` / `textEmbeddingModel` plus the callable form. Spice Cloud auth still goes through the `X-API-KEY` header. So existing call sites such as `spice.chat(model)` and `createSpiceCloud({ baseURL, apiKey })` are source-compatible.

### Breaking change

The provider now requires **`ai@^5`** and is no longer compatible with `ai@^4`. A `changeset` is included for a **minor** release (`0.0.5` → `0.1.0`).

### Validation

This repo has no PR CI, so validated locally with the same commands the release pipeline runs:

- `turbo build` → **2/2 packages built** (provider via `tsup` incl. `.d.ts` typecheck; sample-app via `next build` incl. type-checking) ✅
- `turbo lint` → clean (one pre-existing unused-var warning in `layout.tsx`) ✅
